### PR TITLE
Fix heading size in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ model.soft_destroy!
 model.soft_destroyed? # => true
 ```
 
-# Restore record
+### Restore record
 
 ```ruby
 model.restore


### PR DESCRIPTION
I think it is more suitable that the size of heading 'Restore record' is same as 'Soft-delete record'.  So, I fix it.
