### PR TITLE
Make sure to use Bundler 1.x on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 script: bundle exec rspec
 before_install:
-  - gem install bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 rvm:
   - 2.2.0
   - 2.3.0


### PR DESCRIPTION
Bundler 2.x does not support Ruby 2.2.
So I fixed `.travis.yml` so as to use Bundler 1.x.

See https://docs.travis-ci.com/user/languages/ruby/#bundler-20